### PR TITLE
update README with sdk build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ cd <project-folder>
 # Install dependencies
 npm install
 
+# Build the SDK (required before building the extension)
+cd sdk && npm run build && cd ..
+
 # Build extension
 npm run build
 ```
@@ -45,6 +48,15 @@ After changes, click the refresh icon in `chrome://extensions` to reload.
 ### Build for production
 
 ```bash
+npm run build
+```
+
+### Working with the SDK
+
+The extension depends on the local `@nockbox/iris-sdk` package (in the `sdk/` directory). If you modify SDK source files, rebuild it before building the extension:
+
+```bash
+cd sdk && npm run build && cd ..
 npm run build
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
         "@fontsource/lora": "^5.2.8",
-        "@nockbox/iris-sdk": "file:./sdk",
+        "@nockbox/iris-sdk": "file:sdk",
         "@scure/base": "^2.0.0",
         "@scure/bip39": "^2.0.1",
         "react": "^19.2.0",
@@ -1292,7 +1292,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1428,7 +1427,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -2445,7 +2443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2504,7 +2501,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2680,7 +2676,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
     "@fontsource/lora": "^5.2.8",
-    "@nockbox/iris-sdk": "file:./sdk",
+    "@nockbox/iris-sdk": "file:sdk",
     "@scure/base": "^2.0.0",
     "@scure/bip39": "^2.0.1",
     "react": "^19.2.0",


### PR DESCRIPTION
When building a fresh clone, I encountered the following errors.

```
extension/inpage/index.ts(8,47): error TS2307: Cannot find module '@nockbox/iris-sdk' or its corresponding type declarations.
extension/shared/constants.ts(8,34): error TS2307: Cannot find module '@nockbox/iris-sdk' or its corresponding type declarations.
```

In order to proceed, it was required to build the sdk:

```sh
cd sdk && npm run build && cd ..
```

The README has been updated with the missing step.