### PR TITLE
Feat/public fee estimation

### DIFF
--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -310,6 +310,7 @@ function isProviderMethod(method: unknown): method is string {
     method === PROVIDER_METHODS.SEND_TRANSACTION ||
     method === PROVIDER_METHODS.GET_WALLET_INFO ||
     method === PROVIDER_METHODS.SIGN_TX ||
+    method === PROVIDER_METHODS.ESTIMATE_TRANSACTION_FEE ||
     // Legacy v0 API method
     method === 'nock_signRawTx'
   );
@@ -1042,6 +1043,54 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           await sendBridgedResponse(toInternalProviderError(err));
         }
         return;
+
+      case PROVIDER_METHODS.ESTIMATE_TRANSACTION_FEE: {
+        // Read-only like GET_WALLET_INFO: approved origin + unlocked vault, no approval popup
+        const estimateFeeOrigin = _sender.url || _sender.origin || '';
+        if (!isOriginApproved(estimateFeeOrigin)) {
+          await sendBridgedResponse({ error: { code: 4100, message: 'Unauthorized origin' } });
+          return;
+        }
+
+        if (vault.isLocked()) {
+          await sendBridgedResponse({ error: ERROR_CODES.LOCKED });
+          return;
+        }
+
+        const estimateFeeParams =
+          payload.params && typeof payload.params === 'object' ? payload.params : {};
+        const { to: estimateFeeTo, amount: estimateFeeAmount } = estimateFeeParams;
+        if (!isNockAddress(estimateFeeTo)) {
+          await sendBridgedResponse({ error: ERROR_CODES.BAD_ADDRESS });
+          return;
+        }
+        let estimateFeeAmountNicks: Nicks;
+        try {
+          estimateFeeAmountNicks = parseNicksParam(estimateFeeAmount, 'amount');
+        } catch (err) {
+          await sendBridgedResponse(toInvalidParamsError(err));
+          return;
+        }
+
+        try {
+          const estimateFeeResult = await vault.estimateTransactionFee(
+            estimateFeeTo,
+            estimateFeeAmountNicks
+          );
+          if ('error' in estimateFeeResult) {
+            await sendBridgedResponse({
+              error: { code: -32603, message: estimateFeeResult.error },
+            });
+            return;
+          }
+          // Vault returns a number; the public API uses canonical Nicks (string)
+          await sendBridgedResponse({ fee: String(estimateFeeResult.fee) as Nicks });
+        } catch (err) {
+          console.error('[Background] Public fee estimation failed:', err);
+          await sendBridgedResponse(toInternalProviderError(err));
+        }
+        return;
+      }
 
       // Internal methods (called from popup)
       case INTERNAL_METHODS.SET_AUTO_LOCK:

--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -1617,10 +1617,11 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             const v2Result = await vault.sendTransactionV2(
               txRequest.to,
               txRequest.amount,
-              // Estimated fee: pass undefined so WASM auto-calculates the exact
-              // fee at build time (avoids "Insufficient fee" if the tx shape
-              // changed since estimation). Explicit dApp fees pass through verbatim.
-              txRequest.feeEstimated ? undefined : txRequest.fee,
+              // Always a concrete fee: the dApp's explicit fee, or the wallet's
+              // fresh estimate (matches the popup send flow). This sizes note
+              // selection to the displayed fee rather than the 2-NOCK placeholder
+              // the undefined-fee branch would use.
+              txRequest.fee,
               false,
               undefined,
               'provider_send'
@@ -1633,12 +1634,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             approveTxPending.sendResponse({
               txid: v2Result.txId,
               amount: txRequest.amount,
-              // Report the actual fee used when the dApp omitted fee
-              // (walletTx.fee = constructedTx.feeUsed, set after broadcast;
-              // fall back to the estimate if unset)
-              fee: txRequest.feeEstimated
-                ? (String(v2Result.walletTx.fee ?? txRequest.fee) as Nicks)
-                : txRequest.fee,
+              // Fee charged equals txRequest.fee (applied verbatim as fee override)
+              fee: txRequest.fee,
             });
             cancelPendingRequest(approveTxId);
             processNextRequest();

--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -42,6 +42,7 @@ import type {
   SignRawTxRequest,
   WalletTransaction,
 } from '../shared/types';
+import { resolveTransactionFeeForBuild } from '../shared/transaction-fee';
 
 const vault = new Vault();
 let lastActivity = Date.now();
@@ -1614,17 +1615,18 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           }
 
           try {
+            const feeBuildOptions = resolveTransactionFeeForBuild(
+              txRequest.fee,
+              txRequest.feeEstimated
+            );
             const v2Result = await vault.sendTransactionV2(
               txRequest.to,
               txRequest.amount,
-              // Always a concrete fee: the dApp's explicit fee, or the wallet's
-              // fresh estimate (matches the popup send flow). This sizes note
-              // selection to the displayed fee rather than the 2-NOCK placeholder
-              // the undefined-fee branch would use.
-              txRequest.fee,
+              feeBuildOptions.fee,
               false,
               undefined,
-              'provider_send'
+              'provider_send',
+              { feeSelectionHint: feeBuildOptions.feeSelectionHint }
             );
 
             if ('error' in v2Result) {
@@ -1634,8 +1636,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             approveTxPending.sendResponse({
               txid: v2Result.txId,
               amount: txRequest.amount,
-              // Fee charged equals txRequest.fee (applied verbatim as fee override)
-              fee: txRequest.fee,
+              // Return the actual fee used by WASM, which may differ from the approval estimate.
+              fee: String(v2Result.walletTx.fee) as Nicks,
             });
             cancelPendingRequest(approveTxId);
             processNextRequest();
@@ -1884,7 +1886,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         }
         return;
 
-      case INTERNAL_METHODS.ESTIMATE_TRANSACTION_FEE:
+      case INTERNAL_METHODS.ESTIMATE_SEND_FEE:
         // params: [to, amount] - amount in nicks
         if (vault.isLocked()) {
           sendResponse({ error: ERROR_CODES.LOCKED });

--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -987,13 +987,39 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           return;
         }
         let amountNicks: Nicks;
-        let feeNicks: Nicks;
+        let feeNicks: Nicks | undefined;
         try {
           amountNicks = parseNicksParam(amount, 'amount');
-          feeNicks = parseNicksParam(fee, 'fee', { allowZero: true });
+          feeNicks =
+            fee === undefined || fee === null
+              ? undefined // omitted: estimate below, auto-calc exact fee at build time
+              : parseNicksParam(fee, 'fee', { allowZero: true });
         } catch (err) {
           await sendBridgedResponse(toInvalidParamsError(err));
           return;
+        }
+
+        // Fee omitted: estimate it now so the approval popup can display it.
+        // Estimation failure rejects the request up front (better than a popup
+        // with no fee or a guaranteed-to-fail broadcast).
+        let displayFeeNicks: Nicks;
+        if (feeNicks === undefined) {
+          try {
+            const sendTxEstimate = await vault.estimateTransactionFee(to, amountNicks);
+            if ('error' in sendTxEstimate) {
+              await sendBridgedResponse({
+                error: { code: -32603, message: `Fee estimation failed: ${sendTxEstimate.error}` },
+              });
+              return;
+            }
+            displayFeeNicks = String(sendTxEstimate.fee) as Nicks;
+          } catch (err) {
+            console.error('[Background] Fee estimation for sendTransaction failed:', err);
+            await sendBridgedResponse(toInternalProviderError(err));
+            return;
+          }
+        } else {
+          displayFeeNicks = feeNicks;
         }
 
         // Create transaction approval request
@@ -1003,7 +1029,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           origin: sendTxOrigin,
           to,
           amount: amountNicks,
-          fee: feeNicks,
+          fee: displayFeeNicks,
+          feeEstimated: feeNicks === undefined,
           timestamp: Date.now(),
         };
 
@@ -1590,7 +1617,10 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             const v2Result = await vault.sendTransactionV2(
               txRequest.to,
               txRequest.amount,
-              txRequest.fee,
+              // Estimated fee: pass undefined so WASM auto-calculates the exact
+              // fee at build time (avoids "Insufficient fee" if the tx shape
+              // changed since estimation). Explicit dApp fees pass through verbatim.
+              txRequest.feeEstimated ? undefined : txRequest.fee,
               false,
               undefined,
               'provider_send'
@@ -1603,7 +1633,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             approveTxPending.sendResponse({
               txid: v2Result.txId,
               amount: txRequest.amount,
-              fee: txRequest.fee,
+              // Report the actual fee used when the dApp omitted fee
+              // (walletTx.fee = constructedTx.feeUsed, set after broadcast;
+              // fall back to the estimate if unset)
+              fee: txRequest.feeEstimated
+                ? (String(v2Result.walletTx.fee ?? txRequest.fee) as Nicks)
+                : txRequest.fee,
             });
             cancelPendingRequest(approveTxId);
             processNextRequest();

--- a/extension/popup/screens/SendScreen.tsx
+++ b/extension/popup/screens/SendScreen.tsx
@@ -413,7 +413,7 @@ export function SendScreen() {
 
         const amountNicks = Math.floor(amountNum * NOCK_TO_NICKS);
         const result = await send<{ fee?: number; error?: string }>(
-          INTERNAL_METHODS.ESTIMATE_TRANSACTION_FEE,
+          INTERNAL_METHODS.ESTIMATE_SEND_FEE,
           [addressToUse, amountNicks]
         );
 

--- a/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
+++ b/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
@@ -18,6 +18,7 @@ export function TransactionApprovalScreen() {
 
   const { id, origin, to, amount } = pendingTransactionRequest;
   const fee = pendingTransactionRequest.fee;
+  const isFeeEstimated = Boolean(pendingTransactionRequest.feeEstimated);
   const amountNum = Number(amount);
   const feeNum = Number(fee);
   const totalNum = amountNum + feeNum;
@@ -120,10 +121,11 @@ export function TransactionApprovalScreen() {
               {/* Fee & Total */}
               <div className="rounded-lg p-3 space-y-2" style={{ backgroundColor: surface }}>
                 <div className="flex justify-between text-sm">
-                  <span>Network fee</span>
+                  <span>Network fee{isFeeEstimated ? ' (estimated)' : ''}</span>
                   <div className="text-right">
                     <div>{formatNock(feeNum / NOCK_TO_NICKS)} NOCK</div>
                     <div className="text-[10px]" style={{ color: textMuted }}>
+                      {isFeeEstimated ? '~' : ''}
                       {formatNick(feeNum)} nicks
                     </div>
                   </div>

--- a/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
+++ b/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
@@ -123,18 +123,26 @@ export function TransactionApprovalScreen() {
                 <div className="flex justify-between text-sm">
                   <span>Network fee{isFeeEstimated ? ' (estimated)' : ''}</span>
                   <div className="text-right">
-                    <div>{formatNock(feeNum / NOCK_TO_NICKS)} NOCK</div>
+                    <div>
+                      {isFeeEstimated ? '~' : ''}
+                      {formatNock(feeNum / NOCK_TO_NICKS)} NOCK
+                    </div>
                     <div className="text-[10px]" style={{ color: textMuted }}>
+                      {isFeeEstimated ? '~' : ''}
                       {formatNick(feeNum)} nicks
                     </div>
                   </div>
                 </div>
                 <div className="h-px" style={{ backgroundColor: 'var(--color-surface-700)' }} />
                 <div className="flex justify-between text-sm font-semibold">
-                  <span>Total</span>
+                  <span>Total{isFeeEstimated ? ' (estimated)' : ''}</span>
                   <div className="text-right">
-                    <div>{formatNock(totalNum / NOCK_TO_NICKS)} NOCK</div>
+                    <div>
+                      {isFeeEstimated ? '~' : ''}
+                      {formatNock(totalNum / NOCK_TO_NICKS)} NOCK
+                    </div>
                     <div className="text-[10px] font-normal" style={{ color: textMuted }}>
+                      {isFeeEstimated ? '~' : ''}
                       {formatNick(totalNum)} nicks
                     </div>
                   </div>
@@ -143,7 +151,8 @@ export function TransactionApprovalScreen() {
 
               {/* Balance After */}
               <div className="text-center text-xs py-2" style={{ color: textMuted }}>
-                Balance after: {formatNock(wallet.spendableBalance - totalNum / NOCK_TO_NICKS)} NOCK
+                {isFeeEstimated ? 'Estimated balance after' : 'Balance after'}:{' '}
+                {formatNock(wallet.spendableBalance - totalNum / NOCK_TO_NICKS)} NOCK
               </div>
             </div>
           </div>

--- a/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
+++ b/extension/popup/screens/approvals/TransactionApprovalScreen.tsx
@@ -125,7 +125,6 @@ export function TransactionApprovalScreen() {
                   <div className="text-right">
                     <div>{formatNock(feeNum / NOCK_TO_NICKS)} NOCK</div>
                     <div className="text-[10px]" style={{ color: textMuted }}>
-                      {isFeeEstimated ? '~' : ''}
                       {formatNick(feeNum)} nicks
                     </div>
                   </div>

--- a/extension/shared/constants.ts
+++ b/extension/shared/constants.ts
@@ -5,8 +5,18 @@
  */
 
 // Import provider methods from SDK
-import { PROVIDER_METHODS } from '@nockbox/iris-sdk';
-export { PROVIDER_METHODS };
+import { PROVIDER_METHODS as SDK_PROVIDER_METHODS } from '@nockbox/iris-sdk';
+
+/**
+ * Provider methods: SDK methods plus methods added locally ahead of the next SDK release.
+ * TODO: drop the local ESTIMATE_TRANSACTION_FEE entry once @nockbox/iris-sdk >= 0.3.0
+ * (which defines it) is published and the dependency is upgraded.
+ */
+export const PROVIDER_METHODS = {
+  ...SDK_PROVIDER_METHODS,
+  /** Estimate transaction fee for a dApp send (read-only, no approval popup) */
+  ESTIMATE_TRANSACTION_FEE: 'nock_estimateTransactionFee',
+} as const;
 
 /**
  * Internal Extension Methods - Called by popup UI and other extension components

--- a/extension/shared/constants.ts
+++ b/extension/shared/constants.ts
@@ -122,8 +122,8 @@ export const INTERNAL_METHODS = {
   /** Sign a transaction (internal popup-initiated transactions) */
   SIGN_TRANSACTION: 'wallet:signTransaction',
 
-  /** Estimate transaction fee for a given recipient and amount */
-  ESTIMATE_TRANSACTION_FEE: 'wallet:estimateTransactionFee',
+  /** Estimate transaction fee for a wallet-initiated send. Keep the wire value for compatibility. */
+  ESTIMATE_SEND_FEE: 'wallet:estimateTransactionFee',
 
   /** Estimate max sendable amount (for "send max" feature) */
   ESTIMATE_MAX_SEND: 'wallet:estimateMaxSend',
@@ -374,7 +374,7 @@ export const USER_ACTIVITY_METHODS = new Set([
   INTERNAL_METHODS.GET_MNEMONIC, // Viewing secret phrase is user activity
   INTERNAL_METHODS.SEND_TRANSACTION_V2,
   INTERNAL_METHODS.SEND_BRIDGE_TRANSACTION,
-  INTERNAL_METHODS.ESTIMATE_TRANSACTION_FEE,
+  INTERNAL_METHODS.ESTIMATE_SEND_FEE,
   INTERNAL_METHODS.ESTIMATE_MAX_SEND,
   INTERNAL_METHODS.REPORT_ACTIVITY,
 ]);

--- a/extension/shared/transaction-fee.ts
+++ b/extension/shared/transaction-fee.ts
@@ -1,0 +1,19 @@
+import type { Nicks } from '@nockbox/iris-sdk/wasm';
+
+export type TransactionFeeBuildOptions = {
+  /** Exact fee override supplied by the dApp. Omitted fees must stay undefined for WASM. */
+  fee?: Nicks;
+  /** Advisory fee used only to choose enough notes before WASM calculates the actual fee. */
+  feeSelectionHint?: Nicks;
+};
+
+/**
+ * Preserve the distinction between a dApp fee override and a wallet-generated estimate.
+ * Requests created before `feeEstimated` existed are treated as explicit-fee requests.
+ */
+export function resolveTransactionFeeForBuild(
+  displayedFee: Nicks,
+  feeEstimated?: boolean
+): TransactionFeeBuildOptions {
+  return feeEstimated ? { feeSelectionHint: displayedFee } : { fee: displayedFee };
+}

--- a/extension/shared/types.ts
+++ b/extension/shared/types.ts
@@ -160,8 +160,13 @@ export interface TransactionRequest {
   to: string;
   /** Amount in nicks (WASM Nicks = string) */
   amount: Nicks;
-  /** Transaction fee in nicks */
+  /** Transaction fee in nicks (explicit from dApp, or wallet-estimated when omitted) */
   fee: Nicks;
+  /**
+   * True when the dApp omitted `fee` and `fee` holds a wallet-side estimate;
+   * on approval the exact fee is auto-calculated by WASM at build time.
+   */
+  feeEstimated?: boolean;
   /** Request timestamp */
   timestamp: number;
 }

--- a/extension/shared/vault.ts
+++ b/extension/shared/vault.ts
@@ -70,6 +70,11 @@ import { buildBridgeTransaction, validateBridgeTransaction } from '@nockbox/iris
 import { BRIDGE_CONFIG } from './bridge-config';
 import { rewriteInsufficientFeeErrorToDecimalNock } from './currency';
 
+type SendTransactionV2Options = {
+  /** Advisory fee for note selection only. WASM still calculates the actual fee. */
+  feeSelectionHint?: Nicks;
+};
+
 async function txEngineSettings(blockHeight: number): Promise<wasm.TxEngineSettings> {
   return await getTxEngineSettingsForHeight(blockHeight);
 }
@@ -3449,6 +3454,7 @@ export class Vault {
    * @param fee - Fee in nicks (optional, WASM will calculate if not provided)
    * @param sendMax - If true, sweep all available UTXOs to recipient (no change back)
    * @param priceUsdAtTime - USD price per NOCK at time of transaction (for historical display)
+   * @param options.feeSelectionHint - Advisory fee used only to choose enough notes
    * @returns Transaction result with txId and wallet transaction record
    */
   async sendTransactionV2(
@@ -3457,7 +3463,8 @@ export class Vault {
     fee?: Nicks,
     sendMax?: boolean,
     priceUsdAtTime?: number,
-    origin: WalletTransaction['origin'] = 'popup_send'
+    origin: WalletTransaction['origin'] = 'popup_send',
+    options: SendTransactionV2Options = {}
   ): Promise<
     { txId: string; walletTx: WalletTransaction; broadcasted: boolean } | { error: string }
   > {
@@ -3512,8 +3519,20 @@ export class Vault {
 
           const totalAvailable = availableStoredNotes.reduce((sum, n) => sum + n.assets, 0);
 
-          // 2. Estimate fee if not provided (rough estimate: 2 NOCK should cover most cases)
-          const estimatedFeeNum = fee !== undefined ? Number(fee) : 2 * NOCK_TO_NICKS;
+          // 2. Choose enough notes using the exact override, an advisory estimate, or the
+          // legacy fallback. Only `fee` is forwarded to WASM as an exact fee override.
+          const amountNum = Number(amount);
+          const selectionFeeNicks = fee ?? options.feeSelectionHint;
+          const selectionFeeNum =
+            selectionFeeNicks !== undefined ? Number(selectionFeeNicks) : 2 * NOCK_TO_NICKS;
+          if (
+            !Number.isSafeInteger(amountNum) ||
+            amountNum < 0 ||
+            !Number.isSafeInteger(selectionFeeNum) ||
+            selectionFeeNum < 0
+          ) {
+            return { error: 'Amount or fee exceeds the supported Nicks range' };
+          }
 
           let selectedStoredNotes: typeof availableStoredNotes;
           let expectedChange: number;
@@ -3524,7 +3543,10 @@ export class Vault {
             expectedChange = 0; // All goes to recipient (minus fee)
           } else {
             // NORMAL: Select only notes needed for amount + fee
-            const targetAmount = Number(amount) + estimatedFeeNum;
+            const targetAmount = amountNum + selectionFeeNum;
+            if (!Number.isSafeInteger(targetAmount)) {
+              return { error: 'Amount plus fee exceeds the supported Nicks range' };
+            }
             const selected = selectNotesForAmount(availableStoredNotes, targetAmount);
 
             if (!selected) {
@@ -3535,7 +3557,7 @@ export class Vault {
 
             selectedStoredNotes = selected;
             const selectedTotal = selectedStoredNotes.reduce((sum, n) => sum + n.assets, 0);
-            expectedChange = selectedTotal - Number(amount) - estimatedFeeNum;
+            expectedChange = selectedTotal - amountNum - selectionFeeNum;
           }
 
           selectedNoteIds = selectedStoredNotes.map(n => n.noteId);
@@ -3556,8 +3578,8 @@ export class Vault {
             origin,
             inputNoteIds: selectedNoteIds,
             recipient: to,
-            amount: Number(amount),
-            fee: estimatedFeeNum,
+            amount: amountNum,
+            fee: selectionFeeNum,
             expectedChange: expectedChange > 0 ? expectedChange : 0,
           };
           await this.addWalletTransaction(walletTx);
@@ -3583,6 +3605,10 @@ export class Vault {
             blockHeight
           );
 
+          const actualExpectedChange = sendMax
+            ? 0
+            : Math.max(0, selectedTotal - amountNum - constructedTx.feeUsed);
+
           // 7. Broadcast transaction
           await this.updateWalletTransaction(currentAccount.address, walletTxId, {
             status: 'broadcast_pending',
@@ -3592,11 +3618,13 @@ export class Vault {
 
           // 8. Update tx status to broadcasted
           walletTx.fee = constructedTx.feeUsed;
+          walletTx.expectedChange = actualExpectedChange;
           walletTx.txHash = constructedTx.txId;
           walletTx.trackingTxId = constructedTx.txId;
           walletTx.status = 'broadcasted_unconfirmed';
           await this.updateWalletTransaction(currentAccount.address, walletTxId, {
             fee: constructedTx.feeUsed,
+            expectedChange: actualExpectedChange,
             txHash: constructedTx.txId,
             trackingTxId: constructedTx.txId,
             status: 'broadcasted_unconfirmed',


### PR DESCRIPTION
## Summary

- Add the public `nock_estimateTransactionFee` provider method for approved, unlocked origins.
- Allow `nock_sendTransaction` callers to omit `fee`.
- Display a wallet-generated fee as an estimate before approval while keeping a dApp-supplied fee as an exact override.
- Return and record the fee actually used by the built transaction.

## Compatibility and trust boundary

- Existing dApps that supply `fee` retain their previous exact-fee behavior.
- DApps may omit `fee`; in that case the displayed fee, total, and resulting balance are marked estimated, with an explicit notice that the final network fee is calculated during building and may differ.
- The estimate is used only to select enough notes. WASM still calculates the actual fee when the transaction is built.
- The final integration retries an underfunded advisory build at most once with the remaining locally available notes. Exact-fee requests never retry or change the requested fee.
- The provider response, note reservations, and wallet history are reconciled to the actual inputs, fee, and change selected by WASM.
- Public and internal fee method keys are distinct while their existing wire strings remain unchanged, avoiding the reviewed constant collision without breaking callers.

## Review findings addressed

- Fixed the public/internal RPC constant collision.
- Removed exact-looking UI for estimated fee, total, and balance-after values.
- Corrected the earlier omitted-fee path so an estimate does not silently become an exact WASM override.
- Preserved the estimated-fee marker across a service-worker restart.
- Closed the estimate-drift failure mode with a bounded retry and exact input reconciliation in draft integration PR #55.

## Validation

- Standalone branch: typecheck, formatting, build, and GitHub CI pass.
- Draft integration PR #55 at `f9a62b4`: 24 Vitest tests, typecheck, formatting, production build, and production dependency audit pass locally.

This standalone PR does not contain the final overlap resolution or bounded retry. Draft PR #55 is the phase-one release artifact and should receive the final human review; do not merge #51/#52 independently for release.
